### PR TITLE
ノイズ除去時の退色を修正

### DIFF
--- a/NLM/nlm.py
+++ b/NLM/nlm.py
@@ -10,6 +10,8 @@ parser = argparse.ArgumentParser(description='Non-local means')
 parser.add_argument('input', help='input filename')
 parser.add_argument('--smoothing_strength', '-s', default=1, type=float,
                     help='smoothing strength a.k.a parameter h of non-local means.')
+parser.add_argument('--smoothing_strength_color', '-c', default=1, type=float,
+                    help='smoothing strength for color a.k.a parameter hColor of non-local means.')
 parser.add_argument('--search_window_size', '-w', default=21, type=int,
                     help='search window size')
 parser.add_argument('--patch_size', '-p', default=7, type=int,
@@ -20,9 +22,10 @@ r   = 64
 
 input   = args.input
 param_h = args.smoothing_strength
+param_h_color = args.smoothing_strength_color
 search_size = args.search_window_size
 patch_size  = args.patch_size
-print   'param_h', param_h, 'search', search_size, 'patch', patch_size
+print   'param_h', param_h, 'param_h_color', param_h_color, 'search', search_size, 'patch', patch_size
 
 img = cv2.imread(input)
 h, w    = img.shape[:2]
@@ -31,7 +34,7 @@ h, w    = img.shape[:2]
 cv2.imwrite('result/resize.png', img)
 
 print   'NLM...'
-dst = cv2.fastNlMeansDenoisingColored(img, None, param_h, param_h, patch_size, search_size)
+dst = cv2.fastNlMeansDenoisingColored(img, None, param_h, param_h_color, patch_size, search_size)
 cv2.imwrite('result/result.png', dst)
 
 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
@@ -48,7 +51,7 @@ plt.title('Noisy input')
 plt.subplot(222)
 plt.imshow(dst)
 plt.axis('off')
-plt.title('NL-means, h = {}'.format(param_h))
+plt.title('NL-means, h = {}'.format(param_h) + ', hColor = {}'.format(param_h_color))
 
 plt.subplot(223)
 plt.imshow(img[h/2 - r:h/2 + r, w/2 - r: w/2 + r])

--- a/NLM/nlm.py
+++ b/NLM/nlm.py
@@ -31,7 +31,7 @@ h, w    = img.shape[:2]
 cv2.imwrite('result/resize.png', img)
 
 print   'NLM...'
-dst = cv2.fastNlMeansDenoisingColored(img, param_h, param_h, patch_size, search_size)
+dst = cv2.fastNlMeansDenoisingColored(img, None, param_h, param_h, patch_size, search_size)
 cv2.imwrite('result/result.png', dst)
 
 img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)


### PR DESCRIPTION
http://qiita.com/kibo35/items/c10cfa95c79a5648128c#comment-44699ca4e7a50154dc62 に書いた件です。
- fastNLMeansDenoisingColoredの第2引数が抜けているのを修正（なくてもエラーにはならないが、出力画像が色褪せた感じになる）
- 輝度と色のノイズ除去の強さを別々に指定できるようにコマンドライン引数を追加
